### PR TITLE
Add function liveins/liveouts to interface and backtracking allocator.

### DIFF
--- a/bin/test_framework.rs
+++ b/bin/test_framework.rs
@@ -1617,6 +1617,13 @@ impl regalloc::Function for Func {
     self.insns[last_insn].getTargets()
   }
 
+  fn is_ret(&self, insn: InstIx) -> bool {
+    match &self.insns[insn] {
+      &Inst::Finish { .. } => true,
+      _ => false,
+    }
+  }
+
   /// Provide the defined, used, and modified registers for an instruction.
   fn get_regs(&self, insn: &Self::Inst) -> regalloc::InstRegUses {
     let (d, m, u) = insn.get_reg_usage();
@@ -1708,6 +1715,14 @@ impl regalloc::Function for Func {
   ) -> Option<Self::Inst> {
     // test ISA does not have register-memory ALU instruction forms.
     None
+  }
+
+  fn func_liveins(&self) -> Set<RealReg> {
+    Set::empty()
+  }
+
+  fn func_liveouts(&self) -> Set<RealReg> {
+    Set::empty()
   }
 }
 

--- a/lib/src/data_structures.rs
+++ b/lib/src/data_structures.rs
@@ -550,6 +550,13 @@ impl Reg {
       None
     }
   }
+  pub fn as_real_reg(self) -> Option<RealReg> {
+    if self.is_real() {
+      Some(RealReg { reg: self })
+    } else {
+      None
+    }
+  }
 }
 impl fmt::Debug for Reg {
   fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {

--- a/lib/src/interface.rs
+++ b/lib/src/interface.rs
@@ -98,6 +98,13 @@ pub trait Function {
   /// Get CFG successors for a given block.
   fn block_succs(&self, block: BlockIx) -> Vec<BlockIx>;
 
+  /// Determine whether an instruction is a return instruction.
+  fn is_ret(&self, insn: InstIx) -> bool;
+
+  // --------------------------
+  // Instruction register slots
+  // --------------------------
+
   /// Provide the defined, used, and modified registers for an instruction.
   fn get_regs(&self, insn: &Self::Inst) -> InstRegUses;
 
@@ -118,6 +125,10 @@ pub trait Function {
 
   /// Allow the regalloc to query whether this is a move. Returns (dst, src).
   fn is_move(&self, insn: &Self::Inst) -> Option<(Reg, Reg)>;
+
+  // --------------
+  // Spills/reloads
+  // --------------
 
   /// How many logical spill slots does the given regclass require?  E.g., on a
   /// 64-bit machine, spill slots may nominally be 64-bit words, but a 128-bit
@@ -165,6 +176,22 @@ pub trait Function {
   fn maybe_direct_reload(
     &self, insn: &Self::Inst, reg: VirtualReg, slot: SpillSlot,
   ) -> Option<Self::Inst>;
+
+  // ----------------------------------------------------------
+  // Function liveins, liveouts, and direct-mode real registers
+  // ----------------------------------------------------------
+
+  /// Return the set of registers that should be considered live at the
+  /// beginning of the function. This is semantically equivalent to an
+  /// instruction at the top of the entry block def'ing all registers in this
+  /// set.
+  fn func_liveins(&self) -> Set<RealReg>;
+
+  /// Return the set of registers that should be considered live at the
+  /// end of the function (after every return instruction). This is
+  /// semantically equivalent to an instruction at each block with no successors
+  /// that uses each of these registers.
+  fn func_liveouts(&self) -> Set<RealReg>;
 }
 
 /// The result of register allocation.  Note that allocation can fail!


### PR DESCRIPTION
This change allows the Function to specify that certain registers
(probably real registers, though the interface is general) are live on
function entry -- i.e., have an implicit def before the function runs --
and/or are live on function exit -- i.e., have an implicit use after the
function returns. (Every block without successors is considered a return
point.)

This allows code generators that expect function arguments in certain
real registers, and return the function return value(s) in certain real
registers, to properly use the args and define the retvals without the
allocator complaining (undefined args) or miscompiling (spilled
retvals).

This change modifies the interface and updates the backtracking
allocator, but not the linear-scan allocator. The builtin tests do not
use this feature; I plan to test it from within Cranelift for now
(though we should add better tests here that exercise some sort of ABI,
too).