### PR TITLE
Register allocator checker

### DIFF
--- a/lib/src/analysis.rs
+++ b/lib/src/analysis.rs
@@ -17,6 +17,7 @@ use crate::data_structures::{
 };
 use crate::interface::Function;
 
+#[derive(Clone, Debug)]
 pub enum AnalysisError {
   /// A critical edge from "from" to "to" has been found, and should have been
   /// removed by the caller in the first place.

--- a/lib/src/data_structures.rs
+++ b/lib/src/data_structures.rs
@@ -761,7 +761,7 @@ impl<R: Copy + Clone + PartialEq + Eq + Hash + PartialOrd + Ord + fmt::Debug>
   }
 }
 
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone, PartialEq, Eq, Hash)]
 pub enum SpillSlot {
   SpillSlot(u32),
 }
@@ -827,7 +827,7 @@ impl InstRegUses {
   }
 }
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct SanitizedInstRegUses {
   // These names are different from their unsanitized counterparts so as to
   // make it more difficult to get the two types mixed up.

--- a/lib/src/inst_stream.rs
+++ b/lib/src/inst_stream.rs
@@ -110,7 +110,7 @@ pub(crate) fn apply_reg_uses<F: Function>(
   // Set up checker state, if indicated by our configuration.
   let mut checker: Option<CheckerContext> = None;
   if use_checker {
-    checker = Some(CheckerContext::new(func, insts_to_add));
+    checker = Some(CheckerContext::new(func, reg_universe, insts_to_add));
   }
 
   // Make two copies of the fragment mapping, one sorted by the fragment start

--- a/lib/src/interface.rs
+++ b/lib/src/interface.rs
@@ -234,6 +234,7 @@ pub enum RegAllocAlgorithm {
   Backtracking,
   BacktrackingChecked,
   LinearScan,
+  LinearScanChecked,
 }
 
 pub use crate::analysis::AnalysisError;
@@ -274,8 +275,9 @@ pub fn allocate_registers<F: Function>(
       let use_checker = algorithm == RegAllocAlgorithm::BacktrackingChecked;
       backtracking::alloc_main(func, rreg_universe, use_checker)
     }
-    RegAllocAlgorithm::LinearScan => {
-      linear_scan::run(func, rreg_universe).map_err(|e| RegAllocError::Other(e))
+    RegAllocAlgorithm::LinearScan | RegAllocAlgorithm::LinearScanChecked => {
+      let use_checker = algorithm == RegAllocAlgorithm::LinearScanChecked;
+      linear_scan::run(func, rreg_universe, use_checker)
     }
   }
 }

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -11,6 +11,7 @@ pub mod analysis;
 mod analysis;
 
 mod backtracking;
+mod checker;
 mod data_structures;
 mod inst_stream;
 pub mod interface;

--- a/lib/src/linear_scan.rs
+++ b/lib/src/linear_scan.rs
@@ -2144,7 +2144,7 @@ fn apply_registers<F: Function>(
   let show_traces = env::var("MAP_REGS").is_ok();
   let mut checker: Option<CheckerContext> = None;
   if use_checker {
-    checker = Some(CheckerContext::new(func, memory_moves));
+    checker = Some(CheckerContext::new(func, reg_universe, memory_moves));
   }
 
   for block_id in func.blocks() {


### PR DESCRIPTION
This PR adds a register allocator checker: an analysis that does a dataflow analysis of the register allocator's output, including spills, reloads, moves, and mapped real registers, to ensure that the resulting program has the same semantics as the virtual-register-based input.

The checker is wired into the backtracking allocator (via the `BacktrackingChecked` alternative algorithm choice, because we don't have a separate way to specify flags). Integration into linear-scan should be pretty straightforward too; I just haven't done it yet because the top-level is a bit different (doesn't use `edit_inst_stream`).